### PR TITLE
Address symbols-file-missing-build-depends-package-field

### DIFF
--- a/debian/libpmem1.symbols
+++ b/debian/libpmem1.symbols
@@ -1,4 +1,5 @@
 libpmem.so.1 libpmem1 #MINVER#
+* Build-Depends-Package: libpmem-dev
  LIBPMEM_1.0@LIBPMEM_1.0 1.4
  pmem_check_version@LIBPMEM_1.0 1.4
  pmem_deep_drain@LIBPMEM_1.0 1.4

--- a/debian/libpmemblk1.symbols
+++ b/debian/libpmemblk1.symbols
@@ -1,4 +1,5 @@
 libpmemblk.so.1 libpmemblk1 #MINVER#
+* Build-Depends-Package: libpmemblk-dev
  LIBPMEMBLK_1.0@LIBPMEMBLK_1.0 1.4
  pmemblk_bsize@LIBPMEMBLK_1.0 1.4
  pmemblk_check@LIBPMEMBLK_1.0 1.4

--- a/debian/libpmemlog1.symbols
+++ b/debian/libpmemlog1.symbols
@@ -1,4 +1,5 @@
 libpmemlog.so.1 libpmemlog1 #MINVER#
+* Build-Depends-Package: libpmemlog-dev
  LIBPMEMLOG_1.0@LIBPMEMLOG_1.0 1.4
  pmemlog_append@LIBPMEMLOG_1.0 1.4
  pmemlog_appendv@LIBPMEMLOG_1.0 1.4

--- a/debian/libpmemobj1.symbols
+++ b/debian/libpmemobj1.symbols
@@ -1,4 +1,5 @@
 libpmemobj.so.1 libpmemobj1 #MINVER#
+* Build-Depends-Package: libpmemobj-dev
  LIBPMEMOBJ_1.0@LIBPMEMOBJ_1.0 1.4
  _pobj_cache_invalidate@LIBPMEMOBJ_1.0 1.4
  _pobj_cached_pool@LIBPMEMOBJ_1.0 1.4

--- a/debian/libpmempool1.symbols
+++ b/debian/libpmempool1.symbols
@@ -1,4 +1,5 @@
 libpmempool.so.1 libpmempool1 #MINVER#
+* Build-Depends-Package: libpmempool-dev
  LIBPMEMPOOL_1.0@LIBPMEMPOOL_1.0 1.4
  pmempool_check@LIBPMEMPOOL_1.0 1.4
  pmempool_check_end@LIBPMEMPOOL_1.0 1.4

--- a/debian/librpmem1.symbols
+++ b/debian/librpmem1.symbols
@@ -1,4 +1,5 @@
 librpmem.so.1 librpmem1 #MINVER#
+* Build-Depends-Package: librpmem-dev
  LIBRPMEM_1.0@LIBRPMEM_1.0 1.4
  rpmem_check_version@LIBRPMEM_1.0 1.4
  rpmem_close@LIBRPMEM_1.0 1.4

--- a/debian/libvmem1.symbols
+++ b/debian/libvmem1.symbols
@@ -1,4 +1,5 @@
 libvmem.so.1 libvmem1 #MINVER#
+* Build-Depends-Package: libvmem-dev
  LIBVMEM_1.0@LIBVMEM_1.0 1.4
  vmem_aligned_alloc@LIBVMEM_1.0 1.4
  vmem_calloc@LIBVMEM_1.0 1.4

--- a/debian/libvmmalloc1.symbols
+++ b/debian/libvmmalloc1.symbols
@@ -1,4 +1,5 @@
 libvmmalloc.so.1 libvmmalloc1 #MINVER#
+* Build-Depends-Package: libvmmalloc-dev
  __free_hook@Base 1.4
  __malloc_hook@Base 1.4
  __memalign_hook@Base 1.4


### PR DESCRIPTION
This addresses the https://lintian.debian.org/tags/symbols-file-missing-build-depends-package-field.html lintian check for these library packages:
```
I: libpmem1: symbols-file-missing-build-depends-package-field
I: libvmmalloc1: symbols-file-missing-build-depends-package-field
I: librpmem1: symbols-file-missing-build-depends-package-field
I: libpmempool1: symbols-file-missing-build-depends-package-field
I: libvmem1: symbols-file-missing-build-depends-package-field
I: libpmemobj1: symbols-file-missing-build-depends-package-field
I: libpmemlog1: symbols-file-missing-build-depends-package-field
I: libpmemblk1: symbols-file-missing-build-depends-package-field
```