### PR TITLE
Use dh missing

### DIFF
--- a/debian/not-installed
+++ b/debian/not-installed
@@ -1,0 +1,14 @@
+usr/share/pmreorder/utils.py
+usr/share/pmreorder/memoryoperations.py
+usr/share/pmreorder/pmreorder.py
+usr/share/pmreorder/opscontext.py
+usr/share/pmreorder/statemachine.py
+usr/share/pmreorder/consistencycheckwrap.py
+usr/share/pmreorder/loggingfacility.py
+usr/share/pmreorder/operationfactory.py
+usr/share/pmreorder/reorderengines.py
+usr/share/pmreorder/reorderexceptions.py
+usr/share/pmreorder/binaryoutputhandler.py
+usr/share/pmreorder/markerparser.py
+usr/share/bash-completion/completions/pmempool
+usr/bin/pmreorder

--- a/debian/rules
+++ b/debian/rules
@@ -23,6 +23,9 @@ override_dh_install:
 override_dh_installexamples:
 	dh_installexamples --exclude=.gitignore --exclude=.vcxproj
 
+override_dh_missing:
+	dh_missing --list-missing --exclude=usr/share/man --exclude=usr/lib/$(DEB_HOST_MULTIARCH)/pmdk_debug/ --exclude=usr/share/bash-completion/completions/pmempool
+
 override_dh_auto_test:
 ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
 	# Use fake pmem; we really want tmpfs if possible.


### PR DESCRIPTION
Add a `dh_missing --list` call to `d/rules`, with known exclusions, so that we can become aware of new files in new upstream releases.