### PR TITLE
Add d/README.source

### DIFF
--- a/debian/README.source
+++ b/debian/README.source
@@ -1,10 +1,3 @@
-lintian check: debian-watch-does-not-check-gpg-signature
-========================================================
-Upstream does not distribute detatched gpg signatures
-
-https://github.com/pmem/issues/issues/848
-
-
 lintian check: hardening-no-fortify-functions
 =============================================
 This check is raising warnings for the -debug library packages. As their

--- a/debian/README.source
+++ b/debian/README.source
@@ -1,0 +1,33 @@
+lintian check: debian-watch-does-not-check-gpg-signature
+========================================================
+Upstream does not distribute detatched gpg signatures
+
+https://github.com/pmem/issues/issues/848
+
+
+lintian check: hardening-no-fortify-functions
+=============================================
+This check is raising warnings for the -debug library packages. As their
+respective description says, these packages are meant for special debugging
+cases and should not be installed or used outside of a debugging session.
+Therefore, this lintian warning is not being addressed for the libraries in the
+-debug packages.
+
+Also note that just installing the -debug packages is not enough to have
+applications use them, since they are installed in a path outside of the linker
+search path. The devel manpages for each library explain how to use them.
+
+
+Bundled jemalloc
+================
+The upstream source includes jemalloc version 3.6.0, released 2014-03-31, with
+local modifications, as declared in src/jemalloc/README.libvmem.
+
+Questioned if this was still necessary, and why the changes couldn't be sent
+back to jemalloc, upstream had this to say
+(https://bugs.launchpad.net/ubuntu/+bug/1752378/comments/72):
+
+"""
+We can't upstream those changes, because jemalloc changed too much since we
+forked it.
+"""


### PR DESCRIPTION
This README.source file explains some of the lintian issues and the reason why
jemalloc is bundled.

This is another small piece of delta that Ubuntu has. I had to go through a lot of lintian --pedantic issues in order to get this package accepted into the archive back then, and this was one of them.