### PR TITLE
Re-add rpmemd, but skip on arm64

### DIFF
--- a/debian/tests/control
+++ b/debian/tests/control
@@ -5,3 +5,7 @@ Restrictions: isolation-container
 Tests: daxio-version
 Depends: pmdk-tools
 Restrictions: isolation-container, allow-stderr
+
+Tests: rpmemd-version
+Depends: pmdk-tools
+Restrictions: isolation-container, allow-stderr, skippable

--- a/debian/tests/rpmemd-version
+++ b/debian/tests/rpmemd-version
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+set -ex
+
+arch=$(dpkg --print-architecture)
+if [ "$arch" != "amd64" ]; then
+    echo "Skipping rpmemd test, not available on $arch"
+    exit 77
+fi
+
+pkg_version=$(dpkg-query -f '${Version}\n' -W pmdk-tools | cut -d - -f 1)
+echo "pmdk-tools package version: ${pkg_version}"
+rpmemd_version=$(rpmemd -V 2>&1 | cut -d ' ' -f 3)
+echo "rpmemd version: ${rpmemd_version}"
+if [ "$pkg_version" = "$rpmemd_version" ]; then
+    echo "Version match, OK"
+else
+    echo "Version mismatch, FAIL"
+    exit 1
+fi


### PR DESCRIPTION
I noticed that the rpmemd-version test was removed because it fails on the newly supported arm64 builds, which do not include the rpmemd binary. This re-adds that test, but skips it on arm64, in case you want to have it in debian again.

This assumes that the DEP8 infrastructure where this runs understands the "skippable" restriction, and exit status 77.