### PR TITLE
Only run valgrind tests on amd64

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,8 +13,7 @@ Build-Depends: bash-completion,
                pkg-config,
                python3,
                strace,
-               valgrind,
-               valgrind (>= 1:3.15.0) [arm64],
+               valgrind [amd64]
 Standards-Version: 4.5.0
 Rules-Requires-Root: no
 Homepage: https://pmem.io/pmdk/


### PR DESCRIPTION
Only pull in valgrind for amd64, as the tests triggered by its presence
fail on arm64 and ppc64el (see https://bugs.debian.org/967057)