### PR TITLE
Enable librpmem on ppc64el and arm64

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends: bash-completion,
                debhelper-compat (= 12),
                dh-exec,
                libdaxctl-dev (>= 64),
-               libfabric-dev [amd64],
+               libfabric-dev,
                libndctl-dev (>= 64),
                pandoc,
                pkg-config,
@@ -248,7 +248,7 @@ Description: development files for libpmempool1
  against libpmempool.
 
 Package: librpmem1
-Architecture: amd64
+Architecture: amd64 arm64 ppc64el
 Multi-Arch: same
 Depends: libpmem1 (= ${binary:Version}), ${misc:Depends}, ${shlibs:Depends}
 Description: Persistent Memory remote access support library
@@ -265,7 +265,7 @@ Description: Persistent Memory remote access support library
  for most applications.
 
 Package: librpmem1-debug
-Architecture: amd64
+Architecture: amd64 arm64 ppc64el
 Multi-Arch: same
 Depends: libpmem1-debug (= ${binary:Version}),
          ${misc:Depends},
@@ -289,7 +289,7 @@ Description: Persistent Memory remote access support library — debug build
 
 Package: librpmem-dev
 Section: libdevel
-Architecture: amd64
+Architecture: amd64 arm64 ppc64el
 Multi-Arch: same
 Depends: libpmem-dev (= ${binary:Version}),
          librpmem1 (= ${binary:Version}),

--- a/debian/rules
+++ b/debian/rules
@@ -31,9 +31,7 @@ override_dh_installexamples:
 
 override_dh_installman:
 	dh_installman
-ifeq (amd64,$(DEB_HOST_ARCH))
 	dh_installman -p pmdk-tools doc/rpmemd/*.1
-endif
 
 override_dh_missing:
 	dh_missing --list-missing --exclude=usr/share/man --exclude=usr/lib/$(DEB_HOST_MULTIARCH)/pmdk_debug/ --exclude=usr/share/bash-completion/completions/pmempool

--- a/debian/tests/rpmemd-version
+++ b/debian/tests/rpmemd-version
@@ -3,10 +3,6 @@
 set -ex
 
 arch=$(dpkg --print-architecture)
-if [ "$arch" != "amd64" ]; then
-    echo "Skipping rpmemd test, not available on $arch"
-    exit 77
-fi
 
 pkg_version=$(dpkg-query -f '${Version}\n' -W pmdk-tools | sed 's/~rc/-rc/')
 pkg_version=${pkg_version%-*}


### PR DESCRIPTION
libfabric has recently been enabled for other architectures and librpmem
can now be built too.