### PR TITLE
Temporarily disable obj_ctl_arenas/TEST3 and pmem2_future/TESTS.py on ppc64el

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+pmdk (1.12.0-2) unstable; urgency=medium
+
+  * d/rules: Temporarily disable obj_ctl_arenas/TEST3
+    and pmem2_future/TESTS.py. (Closes: #1012519)
+
+ -- Sergio Durigan Junior <sergiodj@debian.org>  Thu, 23 Jun 2022 18:09:35 -0400
+
 pmdk (1.12.0-1) unstable; urgency=medium
 
   * New upstream release.

--- a/debian/rules
+++ b/debian/rules
@@ -45,5 +45,9 @@ ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
 	rm -f src/test/obj_pool/TEST34
 	# binutils regression #964457
 	rm -rf src/test/scope/TESTS.py
+ifeq ($(DEB_BUILD_ARCH),ppc64el)
+	# https://github.com/pmem/pmdk/issues/5458
+	rm -f src/test/obj_ctl_arenas/TEST3 src/test/pmem2_future/TESTS.py
+endif
 	+$(MAKE) check pycheck $(BUILD_ARGS)
 endif


### PR DESCRIPTION
Ref.: https://github.com/pmem/pmdk/issues/5458

@tuliom suggested that these tests should be disabled while he
investigates the issue.  I have decided to also close the Debian bug
associated with this
(https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1012519), but
arguably one could say that this isn't really fixing the bug so I'm
fine if you choose to remove the `Closes:` part.

Tested this on plummer.d.o and also in an Ubuntu PPA.