### PR TITLE
Bump CMake minimum version.

### DIFF
--- a/src/deps/miniasync/CMakeLists.txt
+++ b/src/deps/miniasync/CMakeLists.txt
@@ -3,7 +3,7 @@
 # Copyright 2021, Intel Corporation
 #
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5)
 
 project(miniasync C)
 set(MINIASYNC_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
Compatibility with CMake < 3.5 has been removed from CMake and fails to build[1] with CMake 4.2.3.

[1] https://launchpadlibrarian.net/852692223/buildlog_ubuntu-resolute-arm64.pmdk_1.13.1-1.1ubuntu4_BUILDING.txt.gz